### PR TITLE
[joyride] Added joyride

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/jquery": "^3.2.17",
     "@types/react": "^16.0.34",
     "@types/react-dom": "^16.0.3",
+    "@types/react-joyride": "^2.0.1",
     "@types/react-paginate": "^4.3.1",
     "es6-promise": "^4.2.2",
     "google-protobuf": "^3.5.0",
@@ -34,6 +35,7 @@
     "jquery": "^3.2.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-joyride": "^2.0.1",
     "react-paginate": "^5.0.0"
   },
   "devDependencies": {

--- a/public/src/components/Main.tsx
+++ b/public/src/components/Main.tsx
@@ -228,7 +228,6 @@ export class Main extends React.Component<MainProps, MainState> {
     componentDidMount() {
         if (!localStorage.getItem('first_time_dalal')) {
             showInfoNotif("Do checkout the help section before you start trading", "New notification");            
-            localStorage.setItem("first_time_dalal",  "yeah");
         }
     }
 

--- a/public/src/components/trading_terminal/TradingTerminal.tsx
+++ b/public/src/components/trading_terminal/TradingTerminal.tsx
@@ -11,6 +11,7 @@ import { TinyNetworth } from "../common/TinyNetworth";
 import { PlaceOrderBox } from "./PlaceOrderBox";
 import { Charts } from "./charts/Charts";
 import { Fragment } from "react";
+import ReactJoyride, { STATUS, StoreState, Step } from 'react-joyride';
 
 export type StockBriefInfo = {
 	id: number
@@ -43,6 +44,7 @@ interface TradingTerminalState {
 	currentStockId: number
 	currentPrice: number
 	stockPricesMap: NumNumMap
+	steps: Step[]
 }
 
 export class TradingTerminal extends React.Component<TradingTerminalProps, TradingTerminalState> {
@@ -54,6 +56,233 @@ export class TradingTerminal extends React.Component<TradingTerminalProps, Tradi
 			currentStockId: currentStockId,
 			currentPrice: this.props.stockPricesMap[currentStockId],
 			stockPricesMap: this.props.stockPricesMap,
+			steps: [
+				{
+					content: (
+					  <React.Fragment>
+						<h3>Welcome to Dalal Street! </h3>
+						<p>Let's get you started with a quick walk through of the game.</p>
+					  </React.Fragment>
+					),
+					placement: 'center',
+					locale: { skip: <strong>Skip</strong> },
+					target: 'body',
+				},
+				{
+					content: 'This is where all the trading happens',
+					placement: 'right',
+					styles: {
+						options: {
+							width: 300,
+						}
+					},
+					target: '.rupee',
+					title: 'Trading Terminal'
+				},
+				{
+					content: "Want to view the stocks you've purchsed? Or the cash you have in hand? All this can be found in your portfolio",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.book',
+					title: 'Portfolio'
+				},
+				{
+					content: "This is where a company initially releases its stocks. You buy stocks from here at the start of the game.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.chart',
+					title: 'Exchange'
+				},
+				{
+					content: "Ever find the need for some quick cash? You can lend your stocks to the bank for some cash and buy them back later.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.university',
+					title: 'Mortgage'
+				},
+				{
+					content: "Want to find out more about the companies that you're going to invest in? This view provides all the details you need.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.suitcase',
+					title: 'Companies'
+				},
+				{
+					content: "Keep yourself upto date with all the latest events. Use the News to predict direction of the market.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.newspaper',
+					title: 'News'
+				},
+				{
+					content: "Want to find out where you stand amongst your fellow traders? Use the Leaderboard to see your rank",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.trophy',
+					title: 'Leaderboard'
+				},
+				{
+					content: "Still confused about something? This page contains all the help you might need to play the game.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.help',
+					title: 'Help'
+				},
+				{
+					content: (
+					  <React.Fragment>
+						<h3>Doing great so far!</h3>
+						<p>So far, you've see most of the core components of the game. Let's go through the Trading Terminal just so you know what's happening.</p>
+					  </React.Fragment>
+					),
+					placement: 'center',
+					locale: { skip: <strong>Skip</strong> },
+					target: 'body',
+				},
+				{
+					content: "Use this search menu to change the company in focus in the Trading Terminal",
+					placement: 'bottom',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '.search',
+					title: 'Company Search'
+				},
+				{
+					content: "This is your inbox. This is where you'll receive all your in-game notifications.",
+					placement: 'bottom',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '#notifbutton',
+					title: 'Inbox'
+				},
+				{
+					content: "This table shows the different buy and sell orders current active for the company in focus.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '#market-depth',
+					title: 'Market Depth'
+				},
+				{
+					target: '#orderbook-menu a:nth-child(2)',
+					content: "Go ahead and click here.",
+					placement: 'right',
+					disableOverlayClose: true,
+					spotlightClicks: true,
+					styles: {
+					  options: {
+						zIndex: 10000,
+					  },
+					  spotlight: {
+						backgroundColor: '#ffffff00',
+					  },
+					},
+					title: 'Trading History'
+				},
+				{
+					content: "This table shows you transactions that have occurred in the past for the company in focus.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  }
+					},
+					target: '#trading-history',
+					title: 'Trading History'
+				},
+				{
+					content: "This graph shows the fluctuations in price for the company in focus.",
+					placement: 'left',
+					styles: {
+					  options: {
+						width: 300,
+					  },
+					  spotlight: {
+						backgroundColor: '#ffffff00',
+					  },
+					},
+					target: '#candles-chart',
+					title: 'Price Chart'
+				},
+				{
+					content: "This is where you'll be placing buy and sell orders. Do checkout the Help section to find out what these different types of order mean.",
+					placement: 'right',
+					styles: {
+					  options: {
+						width: 300,
+					  },
+					  spotlight: {
+						backgroundColor: '#ffffff00',
+					  },
+					},
+					target: '#place-order-box-container',
+					title: 'Order Box'
+				},
+				{
+					content: "Have placed some orders? This is where you'll find them.",
+					placement: 'left',
+					styles: {
+					  options: {
+						width: 300,
+					  },
+					  spotlight: {
+						backgroundColor: '#ffffff00',
+					  },
+					},
+					target: '.no-open-orders',
+					title: 'Open Orders'
+				},
+				{
+					content: (
+					  <React.Fragment>
+						<h3>All set!</h3>
+						<p>The joyride ends here but that's not all the help there is! If you aren't familiar with the basics of the stock market such as what the different
+						types of order mean, the Help section is a MUST-READ!
+						</p>
+					  </React.Fragment>
+					),
+					placement: 'center',
+					locale: { skip: <strong>Skip</strong> },
+					target: 'body',
+				},
+			]
 		};
 	}
 
@@ -85,9 +314,36 @@ export class TradingTerminal extends React.Component<TradingTerminalProps, Tradi
 		});
 	};
 
+	handleJoyrideCallback = (data: any) => {
+		const { status, type } = data;
+		if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+		  localStorage.setItem("first_time_dalal",  "yeah");
+		}
+	}
+
 	render() {
+		const { steps } = this.state;
+		let run = false;
+		if (!localStorage.getItem('first_time_dalal')) {
+			run = true;
+		}
+
 		return (
 			<Fragment>
+				<ReactJoyride
+					callback={this.handleJoyrideCallback}
+					continuous
+					run={run}
+					scrollToFirstStep
+					showProgress
+					showSkipButton
+					steps={steps}
+					styles={{
+						options: {
+						zIndex: 10000,
+						}
+					}}
+				/>
 				<div className="row" id="top_bar">
 					<div id="search-bar">
 						<SearchBar


### PR DESCRIPTION
- Added joyride for first time users.
- The joyride explains NavBar, TopBar and TradingTerminal. The rest of the components seem rather intuitive and the current joyride seems pretty lengthy enough to piss off people to just hit ```Skip``` .
- Right now the content might not be ideal. This can be modified just before the event.
- ```react-joyride``` and ```@types/react-joyride``` were added.