### PR TITLE
[Charts]: Use correct stockId when changing company

### DIFF
--- a/public/src/components/trading_terminal/charts/Charts.tsx
+++ b/public/src/components/trading_terminal/charts/Charts.tsx
@@ -123,7 +123,7 @@ export class Charts extends React.Component<ChartsProps, ChartsState> {
 		historyReq.setStockId(stockId);
 		historyReq.setResolution(intervalTypeToResolutionProto[this.state.interval]);
 
-		const subscriptionId = await subscribe(this.props.sessionMd, DataStreamType.STOCK_HISTORY, this.props.stockId + "");
+		const subscriptionId = await subscribe(this.props.sessionMd, DataStreamType.STOCK_HISTORY, stockId + "");
 
 		this.setState({
 			subscriptionId: subscriptionId,


### PR DESCRIPTION
- Use the correct stockId passed instead of the ```this.props.stockId``` to subscribe to stream
- Fixes issue #239 and #240