### PR TITLE
[bundle]:Decrease bundle.js size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,16 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.DefinePlugin({ //<--key to reduce React's size
+      'process.env': {
+        'NODE_ENV': JSON.stringify('production')
+      }
+    }),
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.AggressiveMergingPlugin(),
+    ],
   resolve: {
     extensions: [".ts", ".tsx", ".js"]
   },


### PR DESCRIPTION
- To fix issue [#112](https://github.com/delta/dalal-street-server/issues/112)

- Right now the size decreases from 2.83 MB to 1.56 MB using plugins.

- The TextEncoding Library issue has not yet been touched though

- Basically followed this article [Two Quick Ways To Reduce React App’s Size In Production](https://medium.com/@rajaraodv/two-quick-ways-to-reduce-react-apps-size-in-production-82226605771a)